### PR TITLE
fix(moveElement-a): negative distance values

### DIFF
--- a/answers/moveElement-a.js
+++ b/answers/moveElement-a.js
@@ -8,7 +8,7 @@ function moveElement(duration, distance, element) {
         const amountToMove = progress * distance;
         element.style.transform = `translateX(${amountToMove}px)`;
 
-        if (amountToMove < distance) {
+        if (progress < 1) {
             requestAnimationFrame(move);
         }
     }


### PR DESCRIPTION
Providing a negative distance value to the moveElement function would cause the amountToMove variable to always be less than the distance variable